### PR TITLE
Fix climate panel visibility and transitions

### DIFF
--- a/exported-assets(1)/app.js
+++ b/exported-assets(1)/app.js
@@ -205,6 +205,19 @@ const panels = [
 // Chart colors
 const chartColors = ['#1FB8CD', '#FFC185', '#B4413C', '#ECEBD5', '#5D878F', '#DB4545', '#D2BA4C', '#964325', '#944454', '#13343B'];
 
+function applyChartTheme() {
+  const styles = getComputedStyle(document.documentElement);
+  const textColor = styles.getPropertyValue('--color-text').trim() || '#333';
+  const borderColor = styles.getPropertyValue('--color-border').trim() || '#ccc';
+  const fontFamily = styles.getPropertyValue('--font-family-base');
+  Chart.defaults.color = textColor;
+  Chart.defaults.borderColor = borderColor;
+  Chart.defaults.font.family = fontFamily;
+  if (Chart.defaults.plugins && Chart.defaults.plugins.legend) {
+    Chart.defaults.plugins.legend.labels.color = textColor;
+  }
+}
+
 // Initialize application when DOM is loaded
 document.addEventListener('DOMContentLoaded', function() {
   try {
@@ -218,6 +231,7 @@ document.addEventListener('DOMContentLoaded', function() {
 // Application initialization
 function initializeApplication() {
   try {
+    applyChartTheme();
     // Immediately populate data first
     populateDataContent();
     

--- a/exported-assets(1)/style.css
+++ b/exported-assets(1)/style.css
@@ -1239,11 +1239,16 @@ select.form-control {
 /* Panel Styles */
 .panel {
   display: none;
-  animation: fadeIn var(--duration-normal) var(--ease-standard);
+  opacity: 0;
+  transform: translateY(20px);
+  transition: opacity var(--duration-normal) var(--ease-standard),
+              transform var(--duration-normal) var(--ease-standard);
 }
 
 .panel.active {
   display: block;
+  opacity: 1;
+  transform: translateY(0);
 }
 
 .panel h2 {


### PR DESCRIPTION
## Summary
- ensure Chart.js uses CSS color variables
- add subtle slide/fade transitions for panels

## Testing
- `python3 -m py_compile exported-assets(1)/script.py`
- `node --check exported-assets(1)/app.js`
- `curl -I http://localhost:8000/'exported-assets(1)'/index.html`

------
https://chatgpt.com/codex/tasks/task_e_683f8bdfdd888325ab5e628d7ef49cd9